### PR TITLE
Update MathJax cdn in display.tpl

### DIFF
--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -9,7 +9,7 @@
  *}
 <script src="{$jQueryUrl}"></script>
 <script src="{$pluginLensPath}/lens.js"></script>
-<script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/javascript">{literal}
 
 	var linkElement = document.createElement("link");


### PR DESCRIPTION
The MathJax CDN hosted at cdn.mathjax.org was shut down on April 30, 2017 and recommends using cdnjs with a specific version number rather than 'latest.'